### PR TITLE
FIX: strip-unit (no use of deprecated slash)

### DIFF
--- a/core.scss
+++ b/core.scss
@@ -9,11 +9,13 @@
 
 */
 
+@use "sass:math";
+
 /// Remove the unit of a length
 /// @param {Number} $number - Number to remove unit from
 /// @return {Number} - Unit-less number
 @function strip-unit($number) {
-  @return ($number / ($number * 0 + 1));
+  @return math.div($number, $number * 0 + 1);
 }
 
 /// @deprecated


### PR DESCRIPTION
Use math.div() instead of deprecated slash because using a slash could prevent the use of modern CSS features. See more: https://sass-lang.com/documentation/breaking-changes/slash-div